### PR TITLE
Experiment: Proxy models for transforming scraped data into OCD format

### DIFF
--- a/calaccess_processed/management/commands/loadocdcandidatecontests.py
+++ b/calaccess_processed/management/commands/loadocdcandidatecontests.py
@@ -3,31 +3,14 @@
 """
 Load CandidateContest and related models with data scraped from the CAL-ACCESS website.
 """
-import re
-from datetime import date
-from django.utils import timezone
-from calaccess_processed import special_elections
-from calaccess_processed.management.commands import LoadOCDModelsCommand
-
-# Database utilities
-from django.db.models import (
-    IntegerField,
-    CharField,
-    Case,
-    When,
-    Q,
-    Value,
-)
+from django.db.models import Case, When, Q, Value
 from django.db.models.functions import Cast, Concat
-
-# Models
-from calaccess_scraped.models import (
-    CandidateElection as ScrapedCandidateElection,
-    IncumbentElection as ScrapedIncumbentElection,
-)
+from django.db.models import IntegerField, CharField
 from calaccess_processed.models import Form501Filing
 from opencivicdata.core.models import Membership, Organization
-from opencivicdata.elections.models import Election, CandidateContest, Candidacy
+from opencivicdata.elections.models import CandidateContest, Candidacy
+from calaccess_processed.management.commands import LoadOCDModelsCommand
+from calaccess_processed.models.proxies import ScrapedCandidateElectionProxy
 
 
 class Command(LoadOCDModelsCommand):
@@ -95,8 +78,11 @@ class Command(LoadOCDModelsCommand):
         members_are_loaded = Membership.objects.exists()
 
         # Loop over scraped_elections
-        for scraped_election in ScrapedCandidateElection.objects.all():
-            ocd_election = self.get_ocd_election(scraped_election)
+        for scraped_election in ScrapedCandidateElectionProxy.objects.all():
+
+            # Get election record
+            ocd_election = scraped_election.get_ocd_election()
+
             # then over candidates in the scraped_election
             for scraped_candidate in scraped_election.candidates.all():
                 if self.verbosity > 2:
@@ -140,7 +126,7 @@ class Command(LoadOCDModelsCommand):
         party = self.lookup_candidate_party_correction(
             scraped_candidate.name,
             ocd_election.date.year,
-            self.parse_election_name(scraped_candidate.election.name)['type'],
+            scraped_candidate.election.parsed_name['type'],
             scraped_candidate.office_name,
         )
 
@@ -255,114 +241,6 @@ class Command(LoadOCDModelsCommand):
 
         return candidacy
 
-    def parse_election_name(self, election_name):
-        """
-        Parse a scraped candidate election name into its constituent parts.
-
-        Parts include:
-        * Four-digit year (int)
-        * Type (str), e.g., "GENERAL", "PRIMARY", "SPECIAL ELECTION", "SPECIAL RUNOFF")
-        * Office (optional str)
-        * District (optional int)
-
-        Returns a dict.
-        """
-        pattern = r'^(?P<year>\d{4}) (?P<type>\b(?:[A-Z]| )+)(?: \((?P<office>(?:[A-Z]| )+)(?P<district>\d+)?\))?$' # NOQA
-        parsed_name = re.match(pattern, election_name).groupdict()
-        parsed_name['year'] = int(parsed_name['year'])
-        parsed_name['type'] = parsed_name['type'].strip()
-        if parsed_name['office']:
-            parsed_name['office'] = parsed_name['office'].strip()
-        if parsed_name['district']:
-            parsed_name['district'] = int(parsed_name['district'])
-        return parsed_name
-
-    def lookup_election_date_from_name(self, election_name):
-        """
-        Use a scraped candidate election name to look up the election date.
-
-        Return a timezone aware date object, if found, else None.
-        """
-        if election_name in (x[0] for x in special_elections.names_to_dates):
-            date = dict(special_elections.names_to_dates)[election_name]
-            date_obj = timezone.datetime.strptime(date, '%Y-%m-%d').date()
-        else:
-            # if not in the hard-coded list above, check the scraped
-            # incumbent elections.
-            parsed_name = self.parse_election_name(election_name)
-            incumbent_elections_q = ScrapedIncumbentElection.objects.filter(
-                date__year=parsed_name['year'],
-                name__icontains=parsed_name['type'],
-            )
-            if incumbent_elections_q.count() == 1:
-                date_obj = incumbent_elections_q[0].date
-            else:
-                try:
-                    date_obj = self.get_regular_election_date(parsed_name['year'], parsed_name['type'])
-                except:
-                    date_obj = None
-        return date_obj
-
-    def get_or_create_election_from_name(self, election_name):
-        """
-        Use the scraped candidate election name to match an OCD Election.
-
-        Returns a tuple (Election object, created), where created is a boolean
-        specifying whether a Election was created.
-        """
-        parsed_name = self.parse_election_name(election_name)
-
-        # Avoid conflating the Feb 2008 Primary with the Jun 2008 Primary
-        if election_name == '2008 PRIMARY':
-            try:
-                ocd_election = Election.objects.get(
-                    name=election_name,
-                    date=date(2008, 6, 3),
-                )
-            except Election.DoesNotExist:
-                ocd_election = self.create_election(
-                    election_name,
-                    date(2008, 6, 3),
-                )
-                created = True
-            else:
-                created = False
-        # See if we can use the name to look up the election date
-        elif self.lookup_election_date_from_name(election_name):
-            date_obj = self.lookup_election_date_from_name(election_name)
-            # Now that we have a date, get or create the Election
-            try:
-                ocd_election = Election.objects.get(date=date_obj)
-            except Election.DoesNotExist:
-                ocd_election = self.create_election(
-                    '{year} {type}'.format(**parsed_name),
-                    date_obj,
-                )
-                created = True
-            else:
-                created = False
-                # if election already exists and is named 'SPECIAL' or
-                # 'RECALL'
-                if (
-                    'SPECIAL' in ocd_election.name.upper() or
-                    'RECALL' in ocd_election.name.upper()
-                ):
-                    # and the provided election_name includes either 'GENERAL'
-                    # or 'PRIMARY'...
-                    if (
-                        re.match(r'^\d{4} GENERAL$', election_name) or
-                        re.match(r'^\d{4} PRIMARY$', election_name)
-                    ):
-                        # update the name
-                        ocd_election.name = election_name
-                        ocd_election.save()
-        # If lookup by name fails, raise an exception.
-        else:
-            raise Exception(
-                "Could not match or find date for %s." % election_name
-            )
-        return (ocd_election, created)
-
     def get_form501_filing(self, scraped_candidate):
         """
         Return a Form501Filing that matches the scraped Candidate.
@@ -375,7 +253,7 @@ class Command(LoadOCDModelsCommand):
 
         Return None can't match to a single Form501Filing.
         """
-        election_data = self.parse_election_name(scraped_candidate.election.name)
+        election_data = scraped_candidate.election.parsed_name
         office_data = self.parse_office_name(scraped_candidate.office_name)
 
         # filter all form501 lookups by office type, district and election year
@@ -458,7 +336,7 @@ class Command(LoadOCDModelsCommand):
         if 'SPECIAL' in scraped_candidate.election.name:
             previous_term_unexpired = True
             scraped_election = scraped_candidate.election.name
-            election_type = self.parse_election_name(scraped_election)['type']
+            election_type = scraped_candidate.election.parsed_name['type']
             contest_name = '{0} ({1})'.format(office_name, election_type)
         else:
             previous_term_unexpired = False
@@ -520,38 +398,6 @@ class Command(LoadOCDModelsCommand):
         else:
             is_incumbent = False
         return is_incumbent
-
-    def get_ocd_election(self, scraped_election):
-        """
-        Get and OCD Election from scraped_election.
-        """
-        # try looking up the election using the scraped id
-        try:
-            ocd_election = Election.objects.filter(
-                identifiers__scheme='calaccess_election_id',
-                identifiers__identifier=scraped_election.scraped_id,
-            ).get()
-        except Election.DoesNotExist:
-            ocd_election, elec_created = self.get_or_create_election_from_name(
-                scraped_election.name,
-            )
-            if elec_created and self.verbosity > 2:
-                self.log(' Created new Election: %s' % ocd_election.name)
-            # Add the missing identifier
-            ocd_election.identifiers.create(
-                scheme='calaccess_election_id',
-                identifier=scraped_election.scraped_id,
-            )
-
-        # Whether Election is new or not, update EventSource
-        ocd_election.sources.update_or_create(
-            url=scraped_election.url,
-            note='Last scraped on {dt:%Y-%m-%d}'.format(
-                dt=scraped_election.last_modified,
-            )
-        )
-
-        return ocd_election
 
     def find_previous_undecided_contest(self, runoff_contest):
         """

--- a/calaccess_processed/management/commands/loadocdcandidatecontests.py
+++ b/calaccess_processed/management/commands/loadocdcandidatecontests.py
@@ -335,7 +335,6 @@ class Command(LoadOCDModelsCommand):
         # previous term of the office was unexpired.
         if 'SPECIAL' in scraped_candidate.election.name:
             previous_term_unexpired = True
-            scraped_election = scraped_candidate.election.name
             election_type = scraped_candidate.election.parsed_name['type']
             contest_name = '{0} ({1})'.format(office_name, election_type)
         else:

--- a/calaccess_processed/management/commands/loadocdcandidateelections.py
+++ b/calaccess_processed/management/commands/loadocdcandidateelections.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Load OCD Election models with data scraped from the CAL-ACCESS website.
+"""
+from datetime import date
+from opencivicdata.core.models import Organization
+from opencivicdata.elections.models import Election
+from calaccess_processed.management.commands import LoadOCDModelsCommand
+from calaccess_processed.models.proxies import ScrapedCandidateElectionProxy
+
+
+class Command(LoadOCDModelsCommand):
+    """
+    Load OCD Election models with data scraped from the CAL-ACCESS website.
+    """
+    help = 'Load OCD Election models with data scraped from the CAL-ACCESS website.'
+
+    def add_arguments(self, parser):
+        """
+        Adds custom arguments specific to this command.
+        """
+        parser.add_argument(
+            "--flush",
+            action="store_true",
+            dest="flush",
+            default=False,
+            help="Flush the database tables filled by this command."
+        )
+
+    def handle(self, *args, **options):
+        """
+        Make it happen.
+        """
+        # Start it up.
+        super(Command, self).handle(*args, **options)
+        self.header("Load Candidate Contests")
+
+        # Flush, if the options has been passed
+        if options['flush']:
+            self.flush()
+
+        # Load everything we can from the scrape
+        self.load()
+
+        # connect runoffs to their previously undecided contests
+        self.success("Done!")
+
+    def flush(self):
+        """
+        Flush the database tables filled by this command.
+        """
+        qs = Election.objects.all()
+        if self.verbosity > 0:
+            self.log("Flushing {} Election objects".format(qs.count()))
+        qs.delete()
+
+    def load(self):
+        """
+        Load OCD Election, CandidateContest and related models with data scraped from CAL-ACCESS website.
+        """
+        # Loop over scraped elections for candidates
+        for scraped_election in ScrapedCandidateElectionProxy.objects.all():
+
+            # Get or create an election record
+            ocd_election, ocd_created = self.get_or_create_ocd_election(scraped_election)
+
+            # Log it out
+            if ocd_created and self.verbosity > 2:
+                self.log(' Created new Election: {}'.format(ocd_election))
+
+            # Whether Election is new or not, update EventSource
+            ocd_election.sources.update_or_create(
+                url=scraped_election.url,
+                note='Last scraped on {:%Y-%m-%d}'.format(scraped_election.last_modified)
+            )
+
+    def get_or_create_ocd_election(self, scraped_election):
+        """
+        Get and OCD Election from scraped_election.
+        """
+        # try looking up the election using the scraped id
+        try:
+            return scraped_election.get_ocd_election(), False
+        except Election.DoesNotExist:
+            pass
+
+        # Parse out data from the scraped object
+        parsed_name = scraped_election.parsed_name
+        parsed_date = scraped_election.parsed_date
+
+        # Handle an edge case with bad data that conflates
+        # the Feb 2008 Primary with the Jun 2008 Primary
+        if scraped_election.name == '2008 PRIMARY':
+            return self.create_election(
+                scraped_election.name,
+                date(2008, 6, 3),
+                scraped_election.scraped_id
+            ), True
+
+        # If we can't parse out a date, we should just quit now
+        if not parsed_date:
+            raise Exception("Could not match or find date for %s." % scraped_election.name)
+
+        # If we can, let's create an election
+        ocd_election = self.create_election(
+            '{year} {type}'.format(**parsed_name),
+            parsed_date,
+            scraped_election.scraped_id
+        )
+
+        # If election does already exists and is named 'SPECIAL' or 'RECALL'...
+        if (
+            'SPECIAL' in ocd_election.name.upper() or
+            'RECALL' in ocd_election.name.upper()
+        ):
+            # ... and the provided election_name includes either 'GENERAL' or 'PRIMARY'...
+            if scraped_election.is_primary() or scraped_election.is_general():
+                # ... update the name.
+                ocd_election.name = scraped_election.name
+                ocd_election.save()
+
+        # Finally pass it out.
+        return ocd_election, True
+
+    def create_election(self, name, date, scraped_id=None):
+        """
+        Create an OCD Election object.
+        """
+        # Pull its parent division within OCD
+        admin = Organization.objects.get_or_create(
+            name='Elections Division',
+            classification='executive',
+            parent=self.sos,
+        )[0]
+
+        # Create the election
+        obj = Election.objects.create(
+            date=date,
+            name=name,
+            administrative_organization=admin,
+            division=self.state_division,
+        )
+
+        # And add the identifier so we can find it in the future using scraped data
+        if scraped_id:
+            obj.identifiers.create(scheme='calaccess_election_id', identifier=scraped_id)
+
+        # Pass it out.
+        return obj

--- a/calaccess_processed/management/commands/loadocdelections.py
+++ b/calaccess_processed/management/commands/loadocdelections.py
@@ -53,6 +53,9 @@ class Command(CalAccessCommand):
         call_command('loadocdretentioncontests', **options)
         self.duration()
 
+        call_command('loadocdcandidateelections', **options)
+        self.duration()
+
         call_command('loadocdcandidatecontests', **options)
         self.duration()
 

--- a/calaccess_processed/models/proxies.py
+++ b/calaccess_processed/models/proxies.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Proxy models for augmenting our source data tables with methods useful for processing.
+"""
+import re
+from datetime import date
+from django.utils import timezone
+from calaccess_processed import special_elections
+from opencivicdata.elections.models import Election
+from calaccess_scraped.models import CandidateElection, IncumbentElection
+
+
+class ScrapedCandidateElectionProxy(CandidateElection):
+    """
+    A proxy for the CandidateElection model in calacess_scraped.
+    """
+    class Meta:
+        """
+        Make this a proxy model.
+        """
+        proxy = True
+
+    def is_primary(self):
+        """
+        Returns whether or now the election was a primary.
+        """
+        return 'PRIMARY' in self.name.upper()
+
+    def is_general(self):
+        """
+        Returns whether or now the election was a general election.
+        """
+        return 'GENERAL' in self.name.upper()
+
+    def is_special(self):
+        """
+        Returns whether or now the election was a special election.
+        """
+        return 'SPECIAL' in self.name.upper()
+
+    def is_recall(self):
+        """
+        Returns whether or now the election was a recall.
+        """
+        return 'RECALL' in self.name.upper()
+
+    def get_ocd_election(self):
+        """
+        Returns an OCD Election object for this record, if it exists.
+        """
+        # If this is the 2008, we have a hacked out edge case solution
+        if self.name == '2008 PRIMARY':
+            return Election.objects.get(name=self.name, date=date(2008, 6, 3))
+
+        # Otherwise proceed by trying to get the record via its scraped id
+        try:
+            return Election.objects.get(
+                identifiers__scheme='calaccess_election_id',
+                identifiers__identifier=self.scraped_id,
+            )
+        except Election.DoesNotExist:
+            # If that doesn't exist, try getting it by date
+            if self.parsed_date:
+                return Election.objects.get(date=self.parsed_date)
+            else:
+                # If that fails raise the DoesNotExist error
+                raise
+
+    @property
+    def parsed_name(self):
+        """
+        Parse a scraped candidate election name into its constituent parts.
+
+        Parts include:
+        * Four-digit year (int)
+        * Type (str), e.g., "GENERAL", "PRIMARY", "SPECIAL ELECTION", "SPECIAL RUNOFF")
+        * Office (optional str)
+        * District (optional int)
+
+        Returns a dict with year, type, office and district as keys.
+        """
+        # Parse out the data
+        pattern = r'^(?P<year>\d{4}) (?P<type>\b(?:[A-Z]| )+)(?: \((?P<office>(?:[A-Z]| )+)(?P<district>\d+)?\))?$' # NOQA
+        parsed_name = re.match(pattern, self.name).groupdict()
+
+        # Clean up the contents
+        parsed_name['year'] = int(parsed_name['year'])
+        parsed_name['type'] = parsed_name['type'].strip()
+        if parsed_name['office']:
+            parsed_name['office'] = parsed_name['office'].strip()
+        if parsed_name['district']:
+            parsed_name['district'] = int(parsed_name['district'])
+
+        # Pass it out
+        return parsed_name
+
+    @property
+    def parsed_date(self):
+        """
+        Use a scraped candidate election name to look up the election date.
+
+        Return a timezone aware date object, if found, else None.
+        """
+        try:
+            # Check if the date is in our hardcoded list of special election
+            date = special_elections.names_to_dates_dict[self.name]
+            return timezone.datetime.strptime(date, '%Y-%m-%d').date()
+        except KeyError:
+            pass
+
+        # If not check the alternative list kept by the scraped IncumbentElection model
+        try:
+            incumbent = IncumbentElection.objects.get(
+                date__year=self.parsed_name['year'],
+                name__icontains=self.parsed_name['type'],
+            )
+            return incumbent.date
+        except (IncumbentElection.DoesNotExist, IncumbentElection.MultipleObjectsReturned):
+            pass
+
+        # If that doesn't work either, try parsing the election date from the name
+        try:
+            return self.guess_election_date()
+        except:
+            # If that fails, just give up and return None
+            return None
+
+    def guess_election_date(self, year, election_type):
+        """
+        Get the date of the election in the given year and type.
+
+        Raise an exception if year is not even or if election_type is not "PRIMARY" or "GENERAL".
+
+        Return a date object.
+        """
+        # Rules defined here:
+        # https://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?lawCode=ELEC&division=1.&title=&part=&chapter=1.&article= # noqa
+
+        # Parse out the data we need from the name
+        parsed_year = self.parsed_name['year']
+        parsed_type = self.parsed_name['type']
+
+        # Make sure it's a regular election year
+        if parsed_year % 2 != 0:
+            raise Exception("Regular elections occur in even years.")
+        elif parsed_type.upper() == 'PRIMARY':
+            # Primary elections are in June
+            month = 6
+        elif parsed_type.upper() == 'GENERAL':
+            # General elections are in November
+            month = 11
+        else:
+            raise Exception("election_type must 'PRIMARY' or 'GENERAL'.")
+
+        # get the first weekday
+        # zero-indexed starting with monday
+        first_weekday = date(parsed_year, month, 1).weekday()
+        # calculate day or first tuesday after first monday
+        day_or_month = (7 - first_weekday) % 7 + 2
+        # Pass it out
+        return date(year, month, day_or_month)

--- a/calaccess_processed/special_elections.py
+++ b/calaccess_processed/special_elections.py
@@ -61,3 +61,5 @@ names_to_dates = (
     ('2001 SPECIAL ELECTION (ASSEMBLY 65)', '2001-2-6'),
     ('2001 SPECIAL ELECTION (STATE SENATE 24)', '2001-3-26'),
 )
+
+names_to_dates_dict = dict(t for t in names_to_dates)

--- a/calaccess_processed/tests/test_candidate_proxy.py
+++ b/calaccess_processed/tests/test_candidate_proxy.py
@@ -15,7 +15,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2016 GENERAL".
         """
-        parsed_name = ScrapedCandidateElectionProxy(name='2016 GENERAL').parse_election_name()
+        parsed_name = ScrapedCandidateElectionProxy(name='2016 GENERAL').parsed_name
         assert parsed_name == {
             'year': 2016,
             'type': 'GENERAL',
@@ -27,7 +27,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2009 SPECIAL ELECTION (STATE SENATE 26)".
         """
-        parsed_name = ScrapedCandidateElectionProxy(name='2009 SPECIAL ELECTION (STATE SENATE 26)').parse_election_name()
+        parsed_name = ScrapedCandidateElectionProxy(name='2009 SPECIAL ELECTION (STATE SENATE 26)').parsed_name
         assert parsed_name == {
             'year': 2009,
             'type': 'SPECIAL ELECTION',
@@ -39,7 +39,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2010 SPECIAL RUNOFF (ASSEMBLY 72)".
         """
-        parsed_name = ScrapedCandidateElectionProxy(name='2010 SPECIAL RUNOFF (ASSEMBLY 72)').parse_election_name()
+        parsed_name = ScrapedCandidateElectionProxy(name='2010 SPECIAL RUNOFF (ASSEMBLY 72)').parsed_name
         assert parsed_name == {
             'year': 2010,
             'type': 'SPECIAL RUNOFF',
@@ -51,7 +51,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2003 SPECIAL ELECTION (GOVERNOR)".
         """
-        parsed_name = ScrapedCandidateElectionProxy(name='2003 SPECIAL ELECTION (GOVERNOR)').parse_election_name()
+        parsed_name = ScrapedCandidateElectionProxy(name='2003 SPECIAL ELECTION (GOVERNOR)').parsed_name
         assert parsed_name == {
             'year': 2003,
             'type': 'SPECIAL ELECTION',

--- a/calaccess_processed/tests/test_candidate_proxy.py
+++ b/calaccess_processed/tests/test_candidate_proxy.py
@@ -4,7 +4,7 @@
 Unittests for management commands.
 """
 from unittest import TestCase
-from calaccess_processed.management.commands.loadocdcandidatecontests import Command
+from calaccess_processed.models.proxies import ScrapedCandidateElectionProxy
 
 
 class LoadCandidateContestCommandTest(TestCase):
@@ -15,7 +15,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2016 GENERAL".
         """
-        parsed_name = Command().parse_election_name('2016 GENERAL')
+        parsed_name = ScrapedCandidateElectionProxy(name='2016 GENERAL').parse_election_name()
         assert parsed_name == {
             'year': 2016,
             'type': 'GENERAL',
@@ -27,7 +27,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2009 SPECIAL ELECTION (STATE SENATE 26)".
         """
-        parsed_name = Command().parse_election_name('2009 SPECIAL ELECTION (STATE SENATE 26)')
+        parsed_name = ScrapedCandidateElectionProxy(name='2009 SPECIAL ELECTION (STATE SENATE 26)').parse_election_name()
         assert parsed_name == {
             'year': 2009,
             'type': 'SPECIAL ELECTION',
@@ -39,7 +39,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2010 SPECIAL RUNOFF (ASSEMBLY 72)".
         """
-        parsed_name = Command().parse_election_name('2010 SPECIAL RUNOFF (ASSEMBLY 72)')
+        parsed_name = ScrapedCandidateElectionProxy(name='2010 SPECIAL RUNOFF (ASSEMBLY 72)').parse_election_name()
         assert parsed_name == {
             'year': 2010,
             'type': 'SPECIAL RUNOFF',
@@ -51,7 +51,7 @@ class LoadCandidateContestCommandTest(TestCase):
         """
         Test .parse_election_name() on "2003 SPECIAL ELECTION (GOVERNOR)".
         """
-        parsed_name = Command().parse_election_name('2003 SPECIAL ELECTION (GOVERNOR)')
+        parsed_name = ScrapedCandidateElectionProxy(name='2003 SPECIAL ELECTION (GOVERNOR)').parse_election_name()
         assert parsed_name == {
             'year': 2003,
             'type': 'SPECIAL ELECTION',


### PR DESCRIPTION
As I was working through Code Rush development, I struggled a bit to get my mind around our most complex management commands: ``localcandidatecontests``.

Two observations stood out to me:

1. The command is doing more than just loading CandidateContest objects. It is also creating the lion's share of our Election records and Candidacies. That requires it to contains numerous model methods that both overlap and spiral off from each other.
2. Several of those methods, with names like ``get_election_from_name``, exist primarily to transform and preprocess records from the scraped data models on an object-by-object basis.

Attached is an experiment with simplifying the command by breaking it apart and offloading the object transformations to [Django's proxy model system](https://docs.djangoproject.com/en/1.11/topics/db/models/#proxy-models).

In addition to separating some of the programming logic for simplicity and readability, my hope is that this technique would allow for unittests tailored for the proxies. That would allow us to verify the many edge cases we need to handle with this difficult dataset. 

Let's talk it over during Monday's class. I'm interested to get your take on this approach.  
